### PR TITLE
[Add] : 로그인 기능 추가

### DIFF
--- a/backend/.idea/gradle.xml
+++ b/backend/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/controller/AuthController.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/controller/AuthController.java
@@ -1,6 +1,7 @@
 package SW_Engineering.Group3.controller;
 
 import SW_Engineering.Group3.domian.Member;
+import SW_Engineering.Group3.dto.LoginDto;
 import SW_Engineering.Group3.dto.Response;
 import SW_Engineering.Group3.dto.SignupDto;
 import SW_Engineering.Group3.service.AuthService;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -25,6 +27,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final Response response;
+    private final PasswordEncoder passwordEncoder;
 
 
     @ApiOperation(
@@ -41,9 +44,11 @@ public class AuthController {
     })
     @PostMapping("/signup")
     public ResponseEntity<?> signupUser(@Validated @RequestBody SignupDto signupDto, BindingResult bindingResult){
-        if(bindingResult.hasErrors()){
-            List<String> errors = bindingResult.getAllErrors().stream().map(e -> e.getDefaultMessage()).collect(Collectors.toList());
-            return response.fail("입력 폼에 유효하지 않은 정보가 있습니다.", HttpStatus.BAD_REQUEST);
+        if(bindingResult.hasErrors()) {
+            if(bindingResult.getFieldError("email") != null){
+                return response.fail("아주대학교 이메일로 회원가입 해주세요.", HttpStatus.BAD_REQUEST);
+            }
+            return response.fail("회원가입 폼에 유효하지 않은 정보가 있습니다.", HttpStatus.BAD_REQUEST);
         }
 
         Long saveMemberId = authService.signupUser(signupDto);
@@ -51,5 +56,26 @@ public class AuthController {
             return response.success("회원가입에 성공했습니다");
         else
             return response.fail("입력하신 이메일은 이미 사용 중입니다.", HttpStatus.BAD_REQUEST);
+    }
+
+    @ApiOperation(
+            value = "사용자 로그인",
+            notes = "아주대학교 이메일과 비밀번호를 이용해 로그인을 시킴"
+    )
+    @ApiImplicitParam(
+            name = "loginDto",
+            value = "사용자가 입력하는 로그인 form"
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "로그인 성공 및 SessionId 발급"),
+            @ApiResponse(code = 400, message = "올바르지 않은 아이디(이메일) 입력\n올바르지 않은 비밀번호 입력\n로그인 정보를 모두 입력하지 않음")
+    })
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Validated @RequestBody LoginDto loginDto, BindingResult bindingResult){
+        if(bindingResult.hasErrors())
+            return response.fail("로그인 정보를 모두 입력해주세요", HttpStatus.BAD_REQUEST);
+
+        return authService.login(loginDto);
+
     }
 }

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/controller/ClubController.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/controller/ClubController.java
@@ -1,0 +1,8 @@
+package SW_Engineering.Group3.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/club")
+public class ClubController {
+
+}

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/domian/UserSession.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/domian/UserSession.java
@@ -1,0 +1,25 @@
+package SW_Engineering.Group3.domian;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSession {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String sessionId;
+    private Long memberId;
+
+    public UserSession(String sessionId, Long memberId){
+        this.sessionId = sessionId;
+        this.memberId = memberId;
+    }
+}

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/dto/LoginDto.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/dto/LoginDto.java
@@ -1,0 +1,24 @@
+package SW_Engineering.Group3.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Access;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginDto {
+
+    private String email;
+    private String password;
+
+    @Builder
+    public LoginDto(String email, String password){
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/dto/Response.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/dto/Response.java
@@ -119,7 +119,9 @@ public class Response {
      * @return 응답 객체
      */
     public ResponseEntity<?> fail(String msg, HttpStatus status) {
-        return fail(Collections.emptyList(), msg, status);
+        return new ResponseEntity<>(Body.builder()
+                .state(status.value())
+                .massage(msg).build(), status);
     }
 
     public ResponseEntity<?> invalidFields(LinkedList<LinkedHashMap<String, String>> errors) {
@@ -130,6 +132,7 @@ public class Response {
                 .massage("")
                 .error(errors)
                 .build();
+
         return ResponseEntity.ok(body);
     }
 }

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/dto/SignupDto.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/dto/SignupDto.java
@@ -7,15 +7,17 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignupDto {
-
-    private String id;
-
+    
     @NotNull
+    @Email
+    @Pattern(regexp = "^[a-zA-Z0-9]+@ajou.ac.kr")
     private String email;
     @NotNull
     private String password;

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/repository/SessionRepository.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/repository/SessionRepository.java
@@ -1,0 +1,10 @@
+package SW_Engineering.Group3.repository;
+
+import SW_Engineering.Group3.domian.UserSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SessionRepository extends JpaRepository<UserSession, Long> {
+
+}

--- a/backend/Group3/src/main/java/SW_Engineering/Group3/service/AuthService.java
+++ b/backend/Group3/src/main/java/SW_Engineering/Group3/service/AuthService.java
@@ -1,14 +1,20 @@
 package SW_Engineering.Group3.service;
 
 import SW_Engineering.Group3.domian.Member;
+import SW_Engineering.Group3.domian.UserSession;
+import SW_Engineering.Group3.dto.LoginDto;
 import SW_Engineering.Group3.dto.Response;
 import SW_Engineering.Group3.dto.SignupDto;
 import SW_Engineering.Group3.repository.MemberRepository;
+import SW_Engineering.Group3.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +23,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final Response response;
     private final PasswordEncoder passwordEncoder;
+    private final SessionRepository sessionRepository;
 
     public Long signupUser(SignupDto signupDto){
 
@@ -28,6 +35,37 @@ public class AuthService {
         }
         else
             return null;
+
+    }
+
+    public ResponseEntity login(LoginDto loginDto){
+
+        String loginEmail = loginDto.getEmail();
+        String loginPassword = loginDto.getPassword();
+
+        //1. 이메일을 기반으로 유저 검색
+        Optional<Member> findMember = memberRepository.findByEmail(loginEmail);
+
+        //2. 유저 정보가 존재하는지 확인
+        if(findMember.isPresent()){ // 유저 정보가 존재하면
+
+            if(passwordEncoder.matches(loginPassword, findMember.get().getPassword())) {
+                String sessionId = UUID.randomUUID().toString();
+                Long userId = findMember.get().getId();
+
+                UserSession userSession = new UserSession(sessionId, userId);
+                sessionRepository.save(userSession); // 세션 생성 후 세션저장소에 저장
+
+                return response.success(sessionId, "로그인에 성공했습니다.", HttpStatus.OK);
+            }
+            else{
+                return response.fail("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+            }
+        }
+        else{ // 유저 정보가 존재하지 않으면
+            return response.fail("존재하지 않는 계정입니다. 다시 확인해주세요", HttpStatus.BAD_REQUEST);
+        }
+
     }
 
 }

--- a/backend/Group3/src/test/java/SW_Engineering/Group3/Group3ApplicationTests.java
+++ b/backend/Group3/src/test/java/SW_Engineering/Group3/Group3ApplicationTests.java
@@ -1,6 +1,8 @@
 package SW_Engineering.Group3;
 
 import SW_Engineering.Group3.domian.Member;
+import SW_Engineering.Group3.dto.LoginDto;
+import SW_Engineering.Group3.dto.Response;
 import SW_Engineering.Group3.dto.SignupDto;
 import SW_Engineering.Group3.repository.MemberRepository;
 import SW_Engineering.Group3.service.AuthService;
@@ -9,6 +11,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -17,11 +21,13 @@ class Group3ApplicationTests {
 
 	@Autowired private AuthService authService;
 	@Autowired private MemberRepository memberRepository;
+	@Autowired private Response response;
 
 
 	@Nested
 	class AuthenticationTest {
 
+		//given
 		@Test
 		void 정상적인_회원가입(){
 			SignupDto signupDto = SignupDto.builder()
@@ -32,14 +38,18 @@ class Group3ApplicationTests {
 					.phoneNumber("010-1234-5678")
 					.build();
 
+			//when
 			Long saveMemberId = authService.signupUser(signupDto);
 			Member findMember = memberRepository.findByEmail(signupDto.getEmail()).get();
 
+			//then
 			Assertions.assertThat(findMember.getId()).isEqualTo(saveMemberId);
 		}
 
 		@Test
 		void 중복이메일_회원가입(){
+
+			//given
 			SignupDto signupDto = SignupDto.builder()
 					.email("dnwls813@ajou.ac.kr")
 					.password("a12345678!")
@@ -47,8 +57,6 @@ class Group3ApplicationTests {
 					.major("소프트웨어학과")
 					.phoneNumber("010-1234-5678")
 					.build();
-
-			Long memberId = authService.signupUser(signupDto);
 
 			SignupDto signupDto2 = SignupDto.builder()
 					.email("dnwls813@ajou.ac.kr")
@@ -58,15 +66,94 @@ class Group3ApplicationTests {
 					.phoneNumber("010-1234-5678")
 					.build();
 
+			//when
+			Long memberId = authService.signupUser(signupDto);
 			Long member2Id = authService.signupUser(signupDto);
 
+			//then
 			Assertions.assertThat(memberId).isNotNull();
 			Assertions.assertThat(member2Id).isNull();
 		}
 
 		@Test
-		void loginTest(){
+		void 로그인_성공(){
 
+			//given
+			SignupDto signupDto = SignupDto.builder()
+					.email("dnwls813@ajou.ac.kr")
+					.password("a12345678!")
+					.studentId("201820772")
+					.major("소프트웨어학과")
+					.phoneNumber("010-1234-5678")
+					.build();
+
+			authService.signupUser(signupDto);
+
+			//when
+			LoginDto loginDto = LoginDto.builder()
+					.email("dnwls813@ajou.ac.kr")
+					.password("a12345678!")
+					.build();
+
+			ResponseEntity responseEntity = authService.login(loginDto);
+
+			//then
+			Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		}
+
+		@Test
+		void 틀린_아이디_로그인(){
+
+			//given
+			SignupDto signupDto = SignupDto.builder()
+					.email("dnwls813@ajou.ac.kr")
+					.password("a12345678!")
+					.studentId("201820772")
+					.major("소프트웨어학과")
+					.phoneNumber("010-1234-5678")
+					.build();
+
+			authService.signupUser(signupDto);
+
+			//when
+			LoginDto loginDto = LoginDto.builder()
+					.email("dnwls123@ajou.ac.kr")
+					.password("a12345678!")
+					.build();
+
+			ResponseEntity responseEntity = authService.login(loginDto);
+
+			//then
+			Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+		}
+
+		@Test
+		void 틀린_비밀번호_로그인(){
+
+			//given
+			SignupDto signupDto = SignupDto.builder()
+					.email("dnwls813@ajou.ac.kr")
+					.password("a12345678!")
+					.studentId("201820772")
+					.major("소프트웨어학과")
+					.phoneNumber("010-1234-5678")
+					.build();
+
+			authService.signupUser(signupDto);
+
+			//when
+			LoginDto loginDto = LoginDto.builder()
+					.email("dnwls813@ajou.ac.kr")
+					.password("a!")
+					.build();
+
+			ResponseEntity responseEntity = authService.login(loginDto);
+			System.out.println(responseEntity.getBody().toString());
+
+			//then
+			Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 		}
 	}
 }


### PR DESCRIPTION
- 로그인 시 SessionId를ResponseBody의 data에 넣어서 보냅니다.

- 아이디/비밀번호 검증 후 올바르지 않을 시 적절한 오류메세지와 함께 400을 반환합니다.

- 자세한 API 형식은 /swagger을 통해 확인하실 수 있습니다.